### PR TITLE
Character Builder v0.3

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -26,6 +26,10 @@
       return this.validate && !this.validate(this.workingValue)
     }
 
+    get source () {
+      return this.label ? `**${this.label}:** ${this.value}` : this.value
+    }
+
     handleOpen () {
       this.isEditingStateful = true
       this.workingValue = this.value
@@ -48,9 +52,8 @@
 <template lang="pug">
   div(v-if="!isActuallyEditing").text-wrap
     div.d-flex.justify-space-between
-      div
-        strong(v-if="label").pr-1 {{ label }}:
-        VueMarkdown(v-if="value", :source="value")
+      div.d-flex
+        VueMarkdown(v-if="source", :source="source").textEditorMarkdown
         span(v-else).grey--text {{ placeholder}}
       v-btn(v-if="hasOwnState", icon, @click="handleOpen")
         v-icon fa-edit
@@ -62,3 +65,9 @@
       v-btn(icon, @click="handleClose")
         v-icon fa-times
 </template>
+
+<style lang="scss">
+  .textEditorMarkdown p {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/modules/CharacterEngine/baseCharacter.json
+++ b/src/modules/CharacterEngine/baseCharacter.json
@@ -64,6 +64,8 @@
   "customLanguages": [],
   "customFeatures": [],
   "customFeats": [],
+  "customTechPowers": [],
+  "customForcePowers": [],
   "settings": {
     "isFixedHitPoints": true,
     "abilityScoreMethod": "Standard Array"

--- a/src/modules/CharacterEngine/baseCharacter.json
+++ b/src/modules/CharacterEngine/baseCharacter.json
@@ -57,7 +57,13 @@
     "hasInspiration": false,
     "featuresTimesUsed": { },
     "conditions": [],
-    "exhaustion": 0
+    "exhaustion": 0,
+    "highLevelCasting": {
+      "level6": false,
+      "level7": false,
+      "level8": false,
+      "level9": false
+    }
   },
   "tweaks": {},
   "customProficiencies": [],

--- a/src/modules/CharacterEngine/generateCasting.ts
+++ b/src/modules/CharacterEngine/generateCasting.ts
@@ -1,7 +1,7 @@
 import { RawCharacterType } from '@/types/rawCharacterTypes'
 import { AbilityScoresType, TechCastingType, ForceCastingType } from '@/types/completeCharacterTypes'
 import { PowerType, ClassType, ArchetypeType } from '@/types/characterTypes'
-import { chain, concat, get, lowerCase } from 'lodash'
+import { chain, concat, get, lowerCase, filter } from 'lodash'
 import applyTweak from '@/utilities/applyTweak'
 
 function getMultiplier (
@@ -113,19 +113,16 @@ export default function generateCasting (
   }
   const forceCastingLevel = getCastingLevel(rawCharacter, myClasses, myArchetypes, 'Force')
   const forcePowersKnown = getPowersKnown(rawCharacter, powers, 'Force')
-  const hasLightPowers = forcePowersKnown.some(power => power.forceAlignment === 'Light')
-  const hasDarkPowers = forcePowersKnown.some(power => power.forceAlignment === 'Dark')
-  const hasUniversalPowers = forcePowersKnown.some(power => power.forceAlignment === 'Universal')
 
   const forceCasting = {
     pointsUsed: rawCharacter.currentStats.forcePointsUsed,
     maxPoints: getPowerPoints(rawCharacter, myClasses, myArchetypes, forceCastingBonus.universal, 'Force'),
-    lightAttackModifier: hasLightPowers && applyTweak(rawCharacter, 'forceCasting.lightAttackModifier', forceCastingBonus.light + proficiencyBonus),
-    lightSaveDC: hasLightPowers && applyTweak(rawCharacter, 'forceCasting.lightSaveDC', 8 + forceCastingBonus.light + proficiencyBonus),
-    darkAttackModifier: hasDarkPowers && applyTweak(rawCharacter, 'forceCasting.darkAttackModifier', forceCastingBonus.dark + proficiencyBonus),
-    darkSaveDC: hasDarkPowers && applyTweak(rawCharacter, 'forceCasting.darkSaveDC', 8 + forceCastingBonus.dark + proficiencyBonus),
-    universalAttackModifier: hasUniversalPowers && applyTweak(rawCharacter, 'forceCasting.universalAttackModifier', forceCastingBonus.universal + proficiencyBonus),
-    universalSaveDC: hasUniversalPowers && applyTweak(rawCharacter, 'forceCasting.universalSaveDC', 8 + forceCastingBonus.universal + proficiencyBonus),
+    lightAttackModifier: applyTweak(rawCharacter, 'forceCasting.lightAttackModifier', forceCastingBonus.light + proficiencyBonus),
+    lightSaveDC: applyTweak(rawCharacter, 'forceCasting.lightSaveDC', 8 + forceCastingBonus.light + proficiencyBonus),
+    darkAttackModifier: applyTweak(rawCharacter, 'forceCasting.darkAttackModifier', forceCastingBonus.dark + proficiencyBonus),
+    darkSaveDC: applyTweak(rawCharacter, 'forceCasting.darkSaveDC', 8 + forceCastingBonus.dark + proficiencyBonus),
+    universalAttackModifier: applyTweak(rawCharacter, 'forceCasting.universalAttackModifier', forceCastingBonus.universal + proficiencyBonus),
+    universalSaveDC: applyTweak(rawCharacter, 'forceCasting.universalSaveDC', 8 + forceCastingBonus.universal + proficiencyBonus),
     maxPowerLevel: getMaxPowerLevel(rawCharacter, forceCastingLevel, 'Force'),
     powersKnown: forcePowersKnown
   }

--- a/src/modules/CharacterEngine/generateCasting.ts
+++ b/src/modules/CharacterEngine/generateCasting.ts
@@ -1,5 +1,5 @@
 import { RawCharacterType } from '@/types/rawCharacterTypes'
-import { AbilityScoresType } from '@/types/completeCharacterTypes'
+import { AbilityScoresType, TechCastingType, ForceCastingType } from '@/types/completeCharacterTypes'
 import { PowerType, ClassType, ArchetypeType } from '@/types/characterTypes'
 import { chain, concat, get, lowerCase } from 'lodash'
 import applyTweak from '@/utilities/applyTweak'
@@ -19,19 +19,26 @@ function getMultiplier (
   return myArchetype ? myArchetype.casterRatio : classMultiplier
 }
 
-function getMaxPowerLevel (
+function getCastingLevel (
   rawCharacter: RawCharacterType,
   myClasses: ClassType[],
   myArchetypes: ArchetypeType[],
   castingType: 'Tech' | 'Force'
-) {
-  const castingLevel = rawCharacter.classes.reduce((acc, { name, archetype, levels }) => acc + (levels * getMultiplier(
+): number {
+  return rawCharacter.classes.reduce((acc, { name, archetype, levels }) => acc + (levels * getMultiplier(
     name,
     myClasses,
     archetype && archetype.name,
     myArchetypes,
     castingType
   ) || 0), 0)
+}
+
+function getMaxPowerLevel (
+  rawCharacter: RawCharacterType,
+  castingLevel: number,
+  castingType: 'Tech' | 'Force'
+) {
   return applyTweak(rawCharacter, lowerCase(castingType) + 'Casting.maxPowerLevel', Math.min(9, Math.ceil(castingLevel / 2)))
 }
 
@@ -60,17 +67,20 @@ function getPowerPoints (
   return applyTweak(rawCharacter, lowerCase(castingType) + 'Casting.maxPoints', maxPoints)
 }
 
+function findPower (power: string, powers: PowerType[]): PowerType | undefined {
+  const powerData = powers.find(({ name }) => name === power)
+  if (!powerData) console.error('Warning: Power not found: ' + power)
+  return powerData
+}
+
 function getPowersKnown (rawCharacter: RawCharacterType, powers: PowerType[], castingType: 'Tech' | 'Force') {
   return chain(rawCharacter.classes)
     .map(myClass => {
       const powerName = (lowerCase(castingType) + 'Powers') as 'techPowers' | 'forcePowers'
       const powerList = concat(myClass[powerName] as string[] || [], get(myClass, 'archetype.' + powerName) || [])
-      return powerList.map(myPower => {
-        const powerData = powers.find(({ name }) => name === myPower)
-        if (!powerData) console.error('Warning: Power not found: ' + myPower)
-        return powerData
-      })
+      return powerList.map(power => findPower(power, powers))
     })
+    .concat(rawCharacter[`custom${castingType}Powers` as 'customForcePowers' | 'customTechPowers'].map(power => findPower(power, powers)))
     .flatten()
     .compact()
     .value()
@@ -83,35 +93,41 @@ export default function generateCasting (
   proficiencyBonus: number,
   myClasses: ClassType[],
   myArchetypes: ArchetypeType[]
-) {
+): { techCasting: false | TechCastingType, forceCasting: false | ForceCastingType } {
   const techCastingBonus = abilityScores.Intelligence.modifier
+  const techCastingLevel = getCastingLevel(rawCharacter, myClasses, myArchetypes, 'Tech')
+  const techCasting = {
+    pointsUsed: rawCharacter.currentStats.techPointsUsed,
+    maxPoints: getPowerPoints(rawCharacter, myClasses, myArchetypes, techCastingBonus, 'Tech'),
+    attackModifier: applyTweak(rawCharacter, 'techCasting.attackModifier', techCastingBonus + proficiencyBonus),
+    saveDC: applyTweak(rawCharacter, 'techCasting.saveDC', 8 + techCastingBonus + proficiencyBonus),
+    maxPowerLevel: getMaxPowerLevel(rawCharacter, techCastingLevel, 'Tech'),
+    powersKnown: getPowersKnown(rawCharacter, powers, 'Tech')
+  }
+  const hasTechCasting = techCastingLevel > 0 || techCasting.powersKnown.length > 0
+
   const forceCastingBonus = {
     light: abilityScores.Wisdom.modifier,
     dark: abilityScores.Charisma.modifier,
     universal: Math.max(abilityScores.Wisdom.modifier, abilityScores.Charisma.modifier)
   }
-  const maxTechLevel = getMaxPowerLevel(rawCharacter, myClasses, myArchetypes, 'Tech')
-  const maxForceLevel = getMaxPowerLevel(rawCharacter, myClasses, myArchetypes, 'Force')
+  const forceCastingLevel = getCastingLevel(rawCharacter, myClasses, myArchetypes, 'Force')
+  const forceCasting = {
+    pointsUsed: rawCharacter.currentStats.forcePointsUsed,
+    maxPoints: getPowerPoints(rawCharacter, myClasses, myArchetypes, forceCastingBonus.universal, 'Force'),
+    lightAttackModifier: applyTweak(rawCharacter, 'forceCasting.lightAttackModifier', forceCastingBonus.light + proficiencyBonus),
+    lightSaveDC: applyTweak(rawCharacter, 'forceCasting.lightSaveDC', 8 + forceCastingBonus.light + proficiencyBonus),
+    darkAttackModifier: applyTweak(rawCharacter, 'forceCasting.darkAttackModifier', forceCastingBonus.dark + proficiencyBonus),
+    darkSaveDC: applyTweak(rawCharacter, 'forceCasting.darkSaveDC', 8 + forceCastingBonus.dark + proficiencyBonus),
+    universalAttackModifier: applyTweak(rawCharacter, 'forceCasting.universalAttackModifier', forceCastingBonus.universal + proficiencyBonus),
+    universalSaveDC: applyTweak(rawCharacter, 'forceCasting.universalSaveDC', 8 + forceCastingBonus.universal + proficiencyBonus),
+    maxPowerLevel: getMaxPowerLevel(rawCharacter, forceCastingLevel, 'Force'),
+    powersKnown: getPowersKnown(rawCharacter, powers, 'Force')
+  }
+  const hasForceCasting = forceCastingLevel > 0 || forceCasting.powersKnown.length > 0
+
   return {
-    techCasting: maxTechLevel > 0 && {
-      pointsUsed: rawCharacter.currentStats.techPointsUsed,
-      maxPoints: getPowerPoints(rawCharacter, myClasses, myArchetypes, techCastingBonus, 'Tech'),
-      attackModifier: applyTweak(rawCharacter, 'techCasting.attackModifier', techCastingBonus + proficiencyBonus),
-      saveDC: applyTweak(rawCharacter, 'techCasting.saveDC', 8 + techCastingBonus + proficiencyBonus),
-      maxPowerLevel: maxTechLevel,
-      powersKnown: getPowersKnown(rawCharacter, powers, 'Tech')
-    },
-    forceCasting: maxForceLevel > 0 && {
-      pointsUsed: rawCharacter.currentStats.forcePointsUsed,
-      maxPoints: getPowerPoints(rawCharacter, myClasses, myArchetypes, forceCastingBonus.universal, 'Force'),
-      lightAttackModifier: applyTweak(rawCharacter, 'forceCasting.lightAttackModifier', forceCastingBonus.light + proficiencyBonus),
-      lightSaveDC: applyTweak(rawCharacter, 'forceCasting.lightSaveDC', 8 + forceCastingBonus.light + proficiencyBonus),
-      darkAttackModifier: applyTweak(rawCharacter, 'forceCasting.darkAttackModifier', forceCastingBonus.dark + proficiencyBonus),
-      darkSaveDC: applyTweak(rawCharacter, 'forceCasting.darkSaveDC', 8 + forceCastingBonus.dark + proficiencyBonus),
-      universalAttackModifier: applyTweak(rawCharacter, 'forceCasting.universalAttackModifier', forceCastingBonus.universal + proficiencyBonus),
-      universalSaveDC: applyTweak(rawCharacter, 'forceCasting.universalSaveDC', 8 + forceCastingBonus.universal + proficiencyBonus),
-      maxPowerLevel: maxForceLevel,
-      powersKnown: getPowersKnown(rawCharacter, powers, 'Force')
-    }
+    techCasting: hasTechCasting && techCasting,
+    forceCasting: hasForceCasting && forceCasting
   }
 }

--- a/src/modules/CharacterEngine/generateCasting.ts
+++ b/src/modules/CharacterEngine/generateCasting.ts
@@ -112,17 +112,22 @@ export default function generateCasting (
     universal: Math.max(abilityScores.Wisdom.modifier, abilityScores.Charisma.modifier)
   }
   const forceCastingLevel = getCastingLevel(rawCharacter, myClasses, myArchetypes, 'Force')
+  const forcePowersKnown = getPowersKnown(rawCharacter, powers, 'Force')
+  const hasLightPowers = forcePowersKnown.some(power => power.forceAlignment === 'Light')
+  const hasDarkPowers = forcePowersKnown.some(power => power.forceAlignment === 'Dark')
+  const hasUniversalPowers = forcePowersKnown.some(power => power.forceAlignment === 'Universal')
+
   const forceCasting = {
     pointsUsed: rawCharacter.currentStats.forcePointsUsed,
     maxPoints: getPowerPoints(rawCharacter, myClasses, myArchetypes, forceCastingBonus.universal, 'Force'),
-    lightAttackModifier: applyTweak(rawCharacter, 'forceCasting.lightAttackModifier', forceCastingBonus.light + proficiencyBonus),
-    lightSaveDC: applyTweak(rawCharacter, 'forceCasting.lightSaveDC', 8 + forceCastingBonus.light + proficiencyBonus),
-    darkAttackModifier: applyTweak(rawCharacter, 'forceCasting.darkAttackModifier', forceCastingBonus.dark + proficiencyBonus),
-    darkSaveDC: applyTweak(rawCharacter, 'forceCasting.darkSaveDC', 8 + forceCastingBonus.dark + proficiencyBonus),
-    universalAttackModifier: applyTweak(rawCharacter, 'forceCasting.universalAttackModifier', forceCastingBonus.universal + proficiencyBonus),
-    universalSaveDC: applyTweak(rawCharacter, 'forceCasting.universalSaveDC', 8 + forceCastingBonus.universal + proficiencyBonus),
+    lightAttackModifier: hasLightPowers && applyTweak(rawCharacter, 'forceCasting.lightAttackModifier', forceCastingBonus.light + proficiencyBonus),
+    lightSaveDC: hasLightPowers && applyTweak(rawCharacter, 'forceCasting.lightSaveDC', 8 + forceCastingBonus.light + proficiencyBonus),
+    darkAttackModifier: hasDarkPowers && applyTweak(rawCharacter, 'forceCasting.darkAttackModifier', forceCastingBonus.dark + proficiencyBonus),
+    darkSaveDC: hasDarkPowers && applyTweak(rawCharacter, 'forceCasting.darkSaveDC', 8 + forceCastingBonus.dark + proficiencyBonus),
+    universalAttackModifier: hasUniversalPowers && applyTweak(rawCharacter, 'forceCasting.universalAttackModifier', forceCastingBonus.universal + proficiencyBonus),
+    universalSaveDC: hasUniversalPowers && applyTweak(rawCharacter, 'forceCasting.universalSaveDC', 8 + forceCastingBonus.universal + proficiencyBonus),
     maxPowerLevel: getMaxPowerLevel(rawCharacter, forceCastingLevel, 'Force'),
-    powersKnown: getPowersKnown(rawCharacter, powers, 'Force')
+    powersKnown: forcePowersKnown
   }
   const hasForceCasting = forceCastingLevel > 0 || forceCasting.powersKnown.length > 0
 

--- a/src/modules/CharacterEngine/generateCasting.ts
+++ b/src/modules/CharacterEngine/generateCasting.ts
@@ -1,4 +1,4 @@
-import { RawCharacterType } from '@/types/rawCharacterTypes'
+import { RawCharacterType, HighLevelCastingType } from '@/types/rawCharacterTypes'
 import { AbilityScoresType, TechCastingType, ForceCastingType } from '@/types/completeCharacterTypes'
 import { PowerType, ClassType, ArchetypeType } from '@/types/characterTypes'
 import { chain, concat, get, lowerCase, filter } from 'lodash'
@@ -93,7 +93,11 @@ export default function generateCasting (
   proficiencyBonus: number,
   myClasses: ClassType[],
   myArchetypes: ArchetypeType[]
-): { techCasting: false | TechCastingType, forceCasting: false | ForceCastingType } {
+): {
+  techCasting: false | TechCastingType,
+  forceCasting: false | ForceCastingType,
+  highLevelCasting: HighLevelCastingType
+} {
   const techCastingBonus = abilityScores.Intelligence.modifier
   const techCastingLevel = getCastingLevel(rawCharacter, myClasses, myArchetypes, 'Tech')
   const techCasting = {
@@ -129,6 +133,7 @@ export default function generateCasting (
   const hasForceCasting = forceCastingLevel > 0 || forceCasting.powersKnown.length > 0
 
   return {
+    highLevelCasting: rawCharacter.currentStats.highLevelCasting,
     techCasting: hasTechCasting && techCasting,
     forceCasting: hasForceCasting && forceCasting
   }

--- a/src/modules/CharacterEngine/generateCharacter.ts
+++ b/src/modules/CharacterEngine/generateCharacter.ts
@@ -70,7 +70,7 @@ export default function generateCharacter (
   const myBackground = backgrounds.find(({ name }) => name === rawCharacter.background.name)
   if (!myBackground) console.error('Background not found: ', rawCharacter.background.name)
   const casting = generateCasting(rawCharacter, abilityScores, powers, proficiencyBonus, myFoundClasses, myArchetypes)
-  const superiority = generateSuperiorty(rawCharacter, abilityScores, proficiencyBonus, maneuvers)
+  const superiority = generateSuperiorty(rawCharacter, myFoundClasses, myArchetypes, abilityScores, proficiencyBonus, maneuvers)
   const features = generateFeatures(
     rawCharacter,
     classFeatures,

--- a/src/modules/CharacterEngine/generateCharacter.ts
+++ b/src/modules/CharacterEngine/generateCharacter.ts
@@ -91,6 +91,8 @@ export default function generateCharacter (
     customProficiencies: rawCharacter.customProficiencies,
     customLanguages: rawCharacter.customLanguages,
     customFeatures: rawCharacter.customFeatures,
+    customTechPowers: rawCharacter.customTechPowers,
+    customForcePowers: rawCharacter.customForcePowers,
     numCustomFeats: rawCharacter.customFeats.length,
     currentLevel,
     classes: rawCharacter.classes.map(({ name, levels, archetype }) => ({ name, levels, archetype: archetype && archetype.name })),

--- a/src/modules/CharacterEngine/generateHitPoints.ts
+++ b/src/modules/CharacterEngine/generateHitPoints.ts
@@ -64,6 +64,7 @@ export default function generateHitPoints (
     hitDiceRestored,
     techPointsUsed: rawCharacter.currentStats.techPointsUsed,
     forcePointsUsed: rawCharacter.currentStats.forcePointsUsed,
+    highLevelCasting: rawCharacter.currentStats.highLevelCasting,
     shortRestFeatures: featuresWithUsage.filter(({ usage }) => usage && usage.recharge === 'shortRest').map(({ name }) => name),
     longRestFeatures: featuresWithUsage.map(({ name }) => name)
   }

--- a/src/modules/CharacterEngine/generateLanguages.ts
+++ b/src/modules/CharacterEngine/generateLanguages.ts
@@ -5,7 +5,6 @@ export default function generateLanguages (rawCharacter: RawCharacterType) {
   return compact([
     'Galactic Basic',
     rawCharacter.species.language,
-    ...(rawCharacter.background.languages || []),
-    ...rawCharacter.classes.map(({ archetype }) => get(archetype, 'silverTongue.language'))
+    ...(rawCharacter.background.languages || [])
   ])
 }

--- a/src/modules/CharacterEngine/generateProficiencies.ts
+++ b/src/modules/CharacterEngine/generateProficiencies.ts
@@ -1,7 +1,7 @@
 import { RawCharacterType } from '@/types/rawCharacterTypes'
 import { ClassType } from '@/types/characterTypes'
 import { CompletedFeatureType } from '@/types/completeCharacterTypes'
-import { compact, uniqBy, lowerCase} from 'lodash'
+import { compact, uniqBy, lowerCase } from 'lodash'
 
 export default function generateProficiencies (
   rawCharacter: RawCharacterType,

--- a/src/modules/CharacterEngine/generateSuperiority.ts
+++ b/src/modules/CharacterEngine/generateSuperiority.ts
@@ -1,56 +1,74 @@
 import { RawCharacterType, RawClassType } from '@/types/rawCharacterTypes'
-import { AbilityScoresType } from '@/types/completeCharacterTypes'
+import { AbilityScoresType, SuperiorityType } from '@/types/completeCharacterTypes'
 import { chain, concat, get } from 'lodash'
-import { ManeuverType } from '@/types/characterTypes'
+import { ManeuverType, ClassType, ArchetypeType } from '@/types/characterTypes'
 import applyTweak from '@/utilities/applyTweak'
 
-const superiorityCalculators: { [myClass: string]: {
-  getMaxDice: (level: number) => number,
-  getDiceSize: (level: number) => number,
-  saveDcAbilities: string[]
-}} = {
-  Fighter: {
-    getMaxDice: (level: number) => (Math.ceil(level + 2) / 8) + 1,
-    getDiceSize: (level: number) => 4,
-    saveDcAbilities: ['Strength', 'Dexterity']
-  },
-  Tactical: {
-    getMaxDice: (level: number) => 2 * ((Math.ceil(level + 2) / 8) + 1),
-    getDiceSize: (level: number) => Math.min(2 * Math.ceil((level - 2) / 4) + 4, 12),
-    saveDcAbilities: ['Strength', 'Dexterity']
-  },
-  Scholar: {
-    getMaxDice: (level: number) => Math.min(2 * Math.ceil((level + 2) / 4), 10),
-    getDiceSize: (level: number) => Math.min(2 * Math.ceil((level - 2) / 4) + 4, 12),
-    saveDcAbilities: ['Intelligence']
-  },
-  Scout: {
-    getMaxDice: (level: number) => (Math.ceil(level + 2) / 8) + 1,
-    getDiceSize: (level: number) => Math.min(2 * Math.ceil((level - 2) / 4) + 4, 12),
-    saveDcAbilities: ['Dexterity']
-  },
-  None: {
-    getMaxDice: (level: number) => 0,
-    getDiceSize: (level: number) => 0,
-    saveDcAbilities: []
-  }
-}
-
-function isSuperiorityClass (myClass: RawClassType) {
+function isSuperiorityClass (myClass: RawClassType): boolean {
   return myClass.name === 'Fighter' ||
     myClass.name === 'Scholar' ||
     !!(myClass.archetype && myClass.archetype.name === 'Deadeye Technique')
 }
 
-function getPrimarySuperiorityClass (rawCharacter: RawCharacterType) {
-  const classData = rawCharacter.classes.find(isSuperiorityClass)
-  const className = classData && ((get(classData, 'archetype.name') === 'Tactical Specialist') ? 'Tactical' : classData.name)
-  const superiorityCalculator = superiorityCalculators[className || 'None']
-  return {
-    ...classData,
-    maxDice: superiorityCalculator.getMaxDice(classData ? classData.levels : 0),
-    diceSize: superiorityCalculator.getDiceSize(classData ? classData.levels : 0),
-    saveDcAbilities: superiorityCalculator.saveDcAbilities
+function getClassField (classData: ClassType, level: number, field: string): string {
+  return get(classData, ['levelChanges', level, field]) as (string | undefined) || '0'
+}
+
+function getArchetypeField (archetypeData: ArchetypeType, level: number, field: string): string {
+  const fieldIndex = field === 'Superiority Dice' ? 1 : 0
+  return get(archetypeData, `leveledTable.${level}.${fieldIndex}.value`) as (string | undefined) || '0'
+}
+
+function getSuperiorityValues (
+  rawCharacter: RawCharacterType,
+  myClasses: ClassType[],
+  myArchetypes: ArchetypeType[]
+): {
+  maxDice: number,
+  diceSize: string,
+  saveDcAbilities: string[]
+} | false {
+  const completeClass = rawCharacter.classes.find(isSuperiorityClass)
+  if (!completeClass) return false
+  const classData = myClasses.find(({ name }) => name === completeClass.name)
+  if (!classData) return false
+  const archetypeData = myArchetypes.find(({ name }) => name === get(completeClass, 'archetype.name'))
+  const multiclassDice = Math.max(0, rawCharacter.classes.filter(isSuperiorityClass).length - 1)
+
+  switch (completeClass.name) {
+    case 'Fighter':
+      const maxDice = parseInt(getClassField(classData, completeClass.levels, 'Superiority Dice')) + multiclassDice
+      const saveDcAbilities = ['Strength', 'Dexterity']
+      const isTactical = completeClass.archetype && completeClass.archetype.name === 'Tactical Specialist'
+      if (isTactical && archetypeData) {
+        return {
+          diceSize: getArchetypeField(archetypeData, completeClass.levels, 'Combat Superiority'),
+          maxDice: maxDice + parseInt(getArchetypeField(archetypeData, completeClass.levels, 'Superiority Dice')),
+          saveDcAbilities
+        }
+      } else if (completeClass.levels === 1) {
+        return false
+      } else {
+        return {
+          diceSize: 'd4',
+          maxDice,
+          saveDcAbilities
+        }
+      }
+    case 'Scholar':
+      return {
+        diceSize: getClassField(classData, completeClass.levels, 'Academic Superiority'),
+        maxDice: parseInt(getClassField(classData, completeClass.levels, 'Superiority Dice')) + multiclassDice,
+        saveDcAbilities: ['Intelligence']
+      }
+    case 'Scout':
+      return archetypeData ? {
+        diceSize: getArchetypeField(archetypeData, completeClass.levels, 'Focused Superiority'),
+        maxDice: parseInt(getArchetypeField(archetypeData, completeClass.levels, 'Superiority Dice')) + multiclassDice,
+        saveDcAbilities: ['Dexterity']
+      } : false
+    default:
+      return false
   }
 }
 
@@ -59,16 +77,12 @@ function getSaveDC (
   proficiencyBonus: number,
   abilityScores: AbilityScoresType,
   saveDcAbilities: string[]
-) {
+): number {
   const maxModifier = Math.max(...saveDcAbilities.map(saveDcAbility => abilityScores[saveDcAbility].modifier))
   return applyTweak(rawCharacter, 'superiority.maneuverSaveDC', 8 + proficiencyBonus + maxModifier)
 }
 
-function getMulticlassDiceBonus (rawCharacter: RawCharacterType) {
-  return Math.max(0, rawCharacter.classes.filter(isSuperiorityClass).length - 1)
-}
-
-function getManeuvers (rawCharacter: RawCharacterType, maneuvers: ManeuverType[]) {
+function getManeuvers (rawCharacter: RawCharacterType, maneuvers: ManeuverType[]): ManeuverType[] {
   return chain(rawCharacter.classes)
     .map((myClass: RawClassType) =>
       concat(myClass.maneuvers || [], (myClass.archetype && myClass.archetype.maneuvers) || []).map(maneuver => {
@@ -84,17 +98,18 @@ function getManeuvers (rawCharacter: RawCharacterType, maneuvers: ManeuverType[]
 
 export default function generateSuperiority (
   rawCharacter: RawCharacterType,
+  myClasses: ClassType[],
+  myArchetypes: ArchetypeType[],
   abilityScores: AbilityScoresType,
   proficiencyBonus: number,
   maneuvers: ManeuverType[]
-) {
-  const primaryClass = getPrimarySuperiorityClass(rawCharacter)
-  const maxDice = applyTweak(rawCharacter, 'superiority.maxDice', primaryClass.maxDice + getMulticlassDiceBonus(rawCharacter))
-  return primaryClass.diceSize !== 0 && {
+): SuperiorityType | false {
+  const superiority = getSuperiorityValues(rawCharacter, myClasses, myArchetypes)
+  return superiority && {
     currentDice: rawCharacter.currentStats.superiorityDiceUsed,
-    maxDice,
-    diceSize: 'd' + primaryClass.diceSize,
-    maneuverSaveDC: getSaveDC(rawCharacter, proficiencyBonus, abilityScores, primaryClass.saveDcAbilities),
+    maxDice: applyTweak(rawCharacter, 'superiority.maxDice', superiority.maxDice),
+    diceSize: superiority.diceSize,
+    maneuverSaveDC: getSaveDC(rawCharacter, proficiencyBonus, abilityScores, superiority.saveDcAbilities),
     maneuvers: getManeuvers(rawCharacter, maneuvers)
   }
 }

--- a/src/pages/MyContent/CharacterBuilder/CharacterBuilderClass.vue
+++ b/src/pages/MyContent/CharacterBuilder/CharacterBuilderClass.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Component, Prop, Vue } from 'vue-property-decorator'
   import { namespace } from 'vuex-class'
-  import { chain, range, merge, omit } from 'lodash'
+  import { chain, range, merge, omit, set } from 'lodash'
   import { ClassType, ArchetypeType } from '@/types/characterTypes'
   import { RawClassType, RawASIType, RawCharacterType } from '@/types/rawCharacterTypes'
   import { CharacterAdvancementType } from '@/types/lookupTypes'
@@ -123,10 +123,13 @@
     handleDeleteClass () {
       const advancement = this.characterAdvancements.find(({ level }) => level === this.totalOtherClassesLevels)
       const experiencePoints = advancement ? advancement.experiencePoints : 0
+      let newClasses = Object.values(omit(this.character.classes, this.index))
+      // Starting class changed, so use its max hit points for level 1
+      if (this.index === 0 && newClasses.length) newClasses[0].hitPoints = newClasses[0].hitPoints.slice(1)
       this.$emit('replaceCharacterProperties', [
         {
           path: 'classes',
-          property: Object.values(omit(this.character.classes, this.index))
+          property: newClasses
         },
         { path: 'experiencePoints', property: experiencePoints }
       ])

--- a/src/pages/MyContent/CharacterBuilder/CharacterBuilderClassDetail.vue
+++ b/src/pages/MyContent/CharacterBuilder/CharacterBuilderClassDetail.vue
@@ -23,7 +23,7 @@
 
 <template lang="pug">
   div.text-left
-    MyDialog(v-model="isClassOpen")
+    MyDialog(v-model="isClassOpen", wide)
       template(v-slot:activator="{ on }")
         v-btn(v-on="on") View Class Details
       template(#title) {{ classData.name }}
@@ -32,7 +32,7 @@
       template(#actions)
         v-spacer
         v-btn(color="primary", text, @click="isClassOpen=false") Close
-    MyDialog(v-if="archetypeName", v-model="isArchetypeOpen").ml-3
+    MyDialog(v-if="archetypeName", v-model="isArchetypeOpen", wide).ml-3
       template(v-slot:activator="{ on }")
         v-btn(v-on="on") View Archetype Details
       template(#title) {{ archetypeName }}

--- a/src/pages/MyContent/CharacterBuilder/CharacterBuilderDescription.vue
+++ b/src/pages/MyContent/CharacterBuilder/CharacterBuilderDescription.vue
@@ -7,6 +7,7 @@
   import CharactersBackgroundDetail from '@/pages/Characters/CharactersBackgroundDetail.vue'
   import { chain } from 'lodash'
   import MySelect from '@/components/MySelect.vue'
+  import MyDialog from '@/components/MyDialog.vue'
 
   const featModule = namespace('feats')
 
@@ -14,7 +15,8 @@
     components: {
       CharactersBackgroundDetail,
       VueMarkdown,
-      MySelect
+      MySelect,
+      MyDialog
     }
   })
   export default class CharacterBuilderDescription extends Vue {
@@ -26,6 +28,8 @@
 
     @featModule.State feats!: FeatType[]
     @featModule.Action fetchFeats!: () => void
+
+    isOpen = false
 
     created () {
       this.fetchFeats()
@@ -125,12 +129,22 @@
       label="Choose an Alignment",
       @change="newAlignment => handleChangeCharacteristic('alignment', newAlignment)"
     )
-    v-autocomplete(
-      :value="currentBackground.name",
-      :items="backgroundChoices",
-      label="Choose a background",
-      @change="handleChangeBackground"
-    )
+    div.d-flex.align-center
+      v-autocomplete(
+        :value="currentBackground.name",
+        :items="backgroundChoices",
+        label="Choose a background",
+        @change="handleChangeBackground"
+      )
+      MyDialog(v-if="currentBackground.name", v-model="isOpen", wide)
+        template(v-slot:activator="{ on }")
+          v-btn(v-on="on").ml-3 View Background Details
+        template(#title) {{ currentBackground.name }}
+        template(#text)
+          CharactersBackgroundDetail(:backgroundName="currentBackground.name", isHidingBack).mt-3
+        template(#actions)
+          v-spacer
+          v-btn(color="primary", text, @click="isOpen=false") Close
     MySelect(
       v-if="chosenBackground",
       :value="currentBackground.feat.name",

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetAbilities.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetAbilities.vue
@@ -40,7 +40,7 @@
         div
           CharacterSheetTweaker(
             :title="ability + ' Saving Throw'",
-            :tweakPaths="[{ name: ability + ' Saving Throw', path: `abilityScores.${ability}.savingThrowModifier` }]",
+            :tweakPaths="[{ name: ability + ' Saving Throw', path: `abilityScores.${ability}.savingThrowModifier`, type: 'proficiency' }]",
             @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
           )
             ProficiencyDots(:proficiency="savingThrow.proficiency")
@@ -50,7 +50,7 @@
             v-for="{ name, proficiency, modifier } in skills",
             :key="name",
             :title="name",
-            :tweakPaths="[{ name, path: `abilityScores.${ability}.skills.${name}` }]",
+            :tweakPaths="[{ name, path: `abilityScores.${ability}.skills.${name}`, type: 'proficiency' }]",
             @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
           )
             ProficiencyDots(v-bind="{ proficiency }")

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetCasting.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetCasting.vue
@@ -4,6 +4,7 @@
   import CharacterSheetModifier from './CharacterSheetModifier.vue'
   import CharacterSheetTweaker from './CharacterSheetTweaker.vue'
   import CharacterSheetExpansionFeatures from './CharacterSheetExpansionFeatures.vue'
+  import CharacterSheetCastingAddPower from './CharacterSheetCastingAddPower.vue'
   import { groupBy } from 'lodash'
   import CharacterSheetTicker from './CharacterSheetTicker.vue'
   import CheckList from '@/components/CheckList.vue'
@@ -14,12 +15,16 @@
       CharacterSheetModifier,
       CharacterSheetTweaker,
       CharacterSheetExpansionFeatures,
-      CharacterSheetTicker
+      CharacterSheetTicker,
+      CharacterSheetCastingAddPower
     }
   })
   export default class CharacterSheetCasting extends Vue {
     @Prop({ type: [ Boolean, Object ] }) readonly techCasting!: false | TechCastingType
     @Prop({ type: [ Boolean, Object ] }) readonly forceCasting!: false | ForceCastingType
+    @Prop(Array) readonly customTechPowers!: string[]
+    @Prop(Array) readonly customForcePowers!: string[]
+
     groupBy = groupBy
 
     powerLevelText (level: number) {
@@ -38,8 +43,15 @@
 
 <template lang="pug">
   div
-    div(v-if="techCasting").mb-3
+    div.d-flex.justify-space-between.align-center
       h2 Tech Casting
+      CharacterSheetCastingAddPower(
+        icon,
+        castingType="Tech",
+        :powersSelected="customTechPowers"
+        @updatePowers="newPowers => $emit('replaceCharacterProperty', { path: 'customTechPowers', property: newPowers })"
+      )
+    div(v-if="techCasting").mb-3
       div.d-flex.align-center
         CharacterSheetTweaker(
           title="Number of Tech Points",
@@ -84,8 +96,15 @@
         CharacterSheetExpansionFeatures(:features="powers")
       div(v-if="techCasting.powersKnown.length <= 0").mt-5
         div Click Edit Character above to choose tech powers
-    div(v-if="forceCasting")
+    div.d-flex.justify-space-between.align-center
       h2 Force Casting
+      CharacterSheetCastingAddPower(
+        icon,
+        castingType="Force",
+        :powersSelected="customForcePowers"
+        @updatePowers="newPowers => $emit('replaceCharacterProperty', { path: 'customForcePowers', property: newPowers })"
+      )
+    div(v-if="forceCasting")
       div.d-flex.align-center
         CharacterSheetTweaker(
           title="Number of Force Points",

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetCasting.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetCasting.vue
@@ -155,6 +155,7 @@
           @changeSelected="handleChangeForcePoints"
         )
       CharacterSheetModifier(
+        v-if="forceCasting.lightAttackModifier !== false",
         :value="forceCasting.lightAttackModifier",
         addPlus,
         label="Light Attack Modifier",
@@ -162,25 +163,14 @@
         @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
       )
       CharacterSheetModifier(
+        v-if="forceCasting.lightSaveDC !== false",
         :value="forceCasting.lightSaveDC",
         label="Light Save DC",
         tweakPath="forceCasting.lightSaveDC",
         @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
       )
       CharacterSheetModifier(
-        :value="forceCasting.darkAttackModifier",
-        addPlus,
-        label="Dark Attack Modifier",
-        tweakPath="forceCasting.darkAttackModifier",
-        @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
-      )
-      CharacterSheetModifier(
-        :value="forceCasting.darkSaveDC",
-        label="Dark Save DC",
-        tweakPath="forceCasting.darkSaveDC",
-        @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
-      )
-      CharacterSheetModifier(
+        v-if="forceCasting.universalAttackModifier !== false",
         :value="forceCasting.universalAttackModifier",
         addPlus,
         label="Universal Attack Modifier",
@@ -188,9 +178,25 @@
         @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
       )
       CharacterSheetModifier(
+        v-if="forceCasting.universalSaveDC !== false",
         :value="forceCasting.universalSaveDC",
         label="Universal Save DC",
         tweakPath="forceCasting.universalSaveDC",
+        @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
+      )
+      CharacterSheetModifier(
+        v-if="forceCasting.darkAttackModifier !== false",
+        :value="forceCasting.darkAttackModifier",
+        addPlus,
+        label="Dark Attack Modifier",
+        tweakPath="forceCasting.darkAttackModifier",
+        @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
+      )
+      CharacterSheetModifier(
+        v-if="forceCasting.darkSaveDC !== false",
+        :value="forceCasting.darkSaveDC",
+        label="Dark Save DC",
+        tweakPath="forceCasting.darkSaveDC",
         @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
       )
       CharacterSheetModifier(

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetCasting.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetCasting.vue
@@ -38,6 +38,24 @@
     handleChangeForcePoints (forcePointsUsed: number) {
       this.$emit('updateCharacter', { currentStats: { forcePointsUsed } })
     }
+
+    castTechPower (powerLevel: string) {
+      if (this.techCasting) {
+        this.handleChangeTechPoints(Math.min(
+          this.techCasting.maxPoints,
+          this.techCasting.pointsUsed + parseInt(powerLevel) + 1
+        ))
+      }
+    }
+
+    castForcePower (powerLevel: string) {
+      if (this.forceCasting) {
+        this.handleChangeForcePoints(Math.min(
+          this.forceCasting.maxPoints,
+          this.forceCasting.pointsUsed + parseInt(powerLevel) + 1
+        ))
+      }
+    }
   }
 </script>
 
@@ -58,7 +76,9 @@
           :tweakPaths="[{ name: 'Number of Tech Points', path: 'techCasting.maxPoints' }]",
           @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
         )
-          h4 Tech Points
+          div.d-flex
+            h4 Tech Points
+            div(v-if="techCasting.maxPoints === 0").caption.ml-3 None
         CharacterSheetTicker(
           v-if="techCasting.maxPoints > 10",
           :current="Math.max(0, techCasting.maxPoints - techCasting.pointsUsed)",
@@ -92,7 +112,15 @@
         @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
       )
       div(v-for="(powers, level) in groupBy(techCasting.powersKnown, 'level')", :key="level")
-        h3.mt-2 {{ powerLevelText(level) }}
+        h3.mt-2.d-flex.justify-space-between.align-end {{ powerLevelText(level) }}
+          v-btn(
+            v-if="level > 0",
+            :disabled="level >= techCasting.maxPoints - techCasting.pointsUsed",
+            color="primary",
+            small,
+            rounded,
+            @click.stop="castTechPower(level)"
+          ).ma-1 Cast
         CharacterSheetExpansionFeatures(:features="powers")
       div(v-if="techCasting.powersKnown.length <= 0").mt-5
         div Click Edit Character above to choose tech powers
@@ -111,7 +139,9 @@
           :tweakPaths="[{ name: 'Number of Force Points', path: 'forceCasting.maxPoints' }]",
           @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
         )
-          h4 Force Points
+          div.d-flex
+            h4 Force Points
+            div(v-if="forceCasting.maxPoints === 0").caption.ml-3 None
         CharacterSheetTicker(
           v-if="forceCasting.maxPoints > 10",
           :current="Math.max(0, forceCasting.maxPoints - forceCasting.pointsUsed)",
@@ -171,7 +201,15 @@
         @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
       )
       div(v-for="(powers, level) in groupBy(forceCasting.powersKnown, 'level')", :key="level")
-        h3.mt-2 {{ powerLevelText(level) }}
+        h3.mt-2.d-flex.justify-space-between.align-end {{ powerLevelText(level) }}
+          v-btn(
+            v-if="level > 0",
+            :disabled="level >= forceCasting.maxPoints - forceCasting.pointsUsed",
+            color="primary",
+            small,
+            rounded,
+            @click.stop="castForcePower(level)"
+          ).ma-1 Cast
         CharacterSheetExpansionFeatures(:features="powers")
       div(v-if="forceCasting.powersKnown.length <= 0").mt-3
         v-btn(color="primary", @click="$emit('goToStep', 2)") Choose Powers

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetCastingAddPower.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetCastingAddPower.vue
@@ -42,6 +42,7 @@
           (!this.alignmentFilter.length || this.alignmentFilter.includes(forceAlignment)) &&
           powerType === this.castingType
         )
+        .sortBy(({ name }) => !this.powersSelected.includes(name))
         .groupBy('level')
         .value()
     }

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetCastingAddPower.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetCastingAddPower.vue
@@ -28,6 +28,7 @@
 
     isOpen = false
     levelFilter = 0
+    alignmentFilter: string[] = []
     range = range
 
     created () {
@@ -36,8 +37,9 @@
 
     get filteredPowers () {
       return chain(this.powers)
-        .filter(({ level, powerType, name }) =>
+        .filter(({ level, powerType, name, forceAlignment }: PowerType) =>
           level <= this.maxPowerLevel &&
+          (!this.alignmentFilter.length || this.alignmentFilter.includes(forceAlignment)) &&
           powerType === this.castingType
         )
         .groupBy('level')
@@ -67,6 +69,14 @@
     template(#title) Choose {{ castingType }} Powers
     template(#text)
       MySelect(v-model="levelFilter", :items="range(0, maxPowerLevel + 1)", label="Filter by Level").mt-3
+      MySelect(
+        v-if="castingType === 'Force'",
+        v-model="alignmentFilter",
+        :items="['Light', 'Universal', 'Dark']",
+        multiple,
+        clearable,
+        label="Filter by Alignment"
+      ).mt-3
       CharacterSheetExpansionFeatures(:features="filteredPowers[levelFilter]", isShowingLevel).text-left
         template(v-slot="{ feature }")
           v-checkbox(

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetCastingAddPower.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetCastingAddPower.vue
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { Component, Prop, Vue } from 'vue-property-decorator'
+  import { namespace } from 'vuex-class'
+  import MyDialog from '@/components/MyDialog.vue'
+  import { PowerType } from '@/types/characterTypes'
+  import { chain, range } from 'lodash'
+  import CharacterSheetExpansionFeatures from './CharacterSheetExpansionFeatures.vue'
+  import MySelect from '@/components/MySelect.vue'
+
+  const powersModule = namespace('powers')
+
+  @Component({
+    components: {
+      CharacterSheetExpansionFeatures,
+      MyDialog,
+      MySelect
+    }
+  })
+  export default class CharacterSheetCastingAddPower extends Vue {
+    @Prop(Boolean) readonly icon!: boolean
+    @Prop(Boolean) readonly disabled!: boolean
+    @Prop(String) readonly castingType!: 'Tech' | 'Force'
+    @Prop({ default: 9, type: Number }) readonly maxPowerLevel!: number
+    @Prop(Array) readonly powersSelected!: string[]
+
+    @powersModule.State powers!: PowerType[]
+    @powersModule.Action fetchPowers!: () => void
+
+    isOpen = false
+    levelFilter = 0
+    range = range
+
+    created () {
+      this.fetchPowers()
+    }
+
+    get filteredPowers () {
+      return chain(this.powers)
+        .filter(({ level, powerType, name }) =>
+          level <= this.maxPowerLevel &&
+          powerType === this.castingType
+        )
+        .groupBy('level')
+        .value()
+    }
+
+    isDisabled (powerName: string) {
+      return this.disabled && !this.powersSelected.includes(powerName)
+    }
+
+    togglePower (powerName: string) {
+      const isSelected = this.powersSelected.includes(powerName)
+      const powersWithoutNew = this.powersSelected.filter(power => power !== powerName)
+      const powersWithNew = this.powersSelected.concat(powerName)
+      this.$emit('updatePowers', isSelected ? powersWithoutNew : powersWithNew)
+    }
+  }
+</script>
+
+<template lang="pug">
+  MyDialog(v-model="isOpen")
+    template(v-slot:activator="{ on }")
+      div.text-center.mt-2
+        v-btn(v-on="on", :icon="icon", @click="levelFilter=0", color="primary")
+          v-icon(v-if="icon") fa-plus
+          template(v-else) Choose {{ castingType }} Powers
+    template(#title) Choose {{ castingType }} Powers
+    template(#text)
+      MySelect(v-model="levelFilter", :items="range(0, maxPowerLevel + 1)", label="Filter by Level").mt-3
+      CharacterSheetExpansionFeatures(:features="filteredPowers[levelFilter]", isShowingLevel).text-left
+        template(v-slot="{ feature }")
+          v-checkbox(
+            :input-value="powersSelected.includes(feature.name)"
+            color="primary",
+            hide-details,
+            :indeterminate="isDisabled(feature.name)",
+            :disabled="isDisabled(feature.name)",
+            :class="$style.checkbox",
+            @click.stop="togglePower(feature.name)"
+          )
+    template(#actions)
+      v-spacer
+      v-btn(color="primary", text, @click="isOpen=false") Done
+</template>
+
+<style lang="scss" module>
+  .checkbox {
+    flex: none !important;
+    margin-top: 0 !important;
+  }
+</style>

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetCombat.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetCombat.vue
@@ -93,8 +93,8 @@
         v-btn(icon, color="primary")
           v-icon fa-edit
     CharacterSheetWeapon(
-      v-for="weapon in weapons",
-      :key="weapon.name",
+      v-for="(weapon, index) in weapons",
+      :key="index",
       v-bind="{ weapon }",
       @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"
     )

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetConditions.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetConditions.vue
@@ -10,11 +10,11 @@
   const conditionsModule = namespace('conditions')
 
   @Component({
-    components: ({
+    components: {
       MyDialog,
       VueMarkdown,
       MySelect
-    })
+    }
   })
   export default class CharacterSheetConditions extends Vue {
     @Prop(Array) readonly myConditions!: ConditionType[]

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetEquipment.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetEquipment.vue
@@ -32,7 +32,7 @@
     v-expansion-panels(accordion, multiple)
       CharacterSheetEquipmentPanel(
         v-for="(item, index) in equipment",
-        :key="item.name",
+        :key="index",
         v-bind="{ item, index }",
         @updateCharacter="newCharacter => $emit('updateCharacter', newCharacter)",
         @deleteCharacterProperty="payload => $emit('deleteCharacterProperty', payload)"

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetEquipmentAdder.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetEquipmentAdder.vue
@@ -9,10 +9,10 @@
   const equipmentModule = namespace('equipment')
 
   @Component({
-    components: ({
+    components: {
       MyDialog,
       MySelect
-    })
+    }
   })
   export default class CharacterSheetEquipmentAdder extends Vue {
     @Prop(Number) readonly position!: number

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetExpansionFeatures.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetExpansionFeatures.vue
@@ -21,7 +21,7 @@
 
 <template lang="pug">
   v-expansion-panels(accordion, multiple)
-    v-expansion-panel(v-for="feature in features", :key="feature.name").powerPanel
+    v-expansion-panel(v-for="(feature, index) in features", :key="index").powerPanel
       v-expansion-panel-header.pa-3
         div.d-flex.align-center
           slot(v-bind="{ feature }")

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetProficienciesList.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetProficienciesList.vue
@@ -33,13 +33,14 @@
     isExpertise = false
     chosenCategory = ''
     newProficiency = ''
+    toolCategories = ['Tool', 'MusicalInstrument', 'Kit', 'GamingSet']
 
     created () {
       this.fetchSkills()
       this.fetchEquipment()
     }
 
-    get allProficiencies () {
+    get allProficiencies (): { [category: string]: string[] } {
       return {
         Weapons: [
           'Simple Vibroweapons',
@@ -51,21 +52,12 @@
           ...this.equipment.filter(({ equipmentCategory }) => equipmentCategory === 'Weapon').map(({ name }) => name)
         ],
         ...chain(this.equipment)
-          .filter(({ equipmentCategory }) => ['Tool', 'MusicalInstrument', 'Kit', 'GamingSet'].includes(equipmentCategory))
+          .filter(({ equipmentCategory }) => this.toolCategories.includes(equipmentCategory))
           .groupBy('equipmentCategory')
           .mapValues(items => items.map(({ name }) => name))
           .mapKeys((list, key) => startCase(key))
           .value(),
-        Armor: ['Light Armor', 'Medium Armor', 'Heavy Armor'],
-        'Saving Throws': [
-          'Dexterity Saving Throws',
-          'Wisdom Saving Throws',
-          'Constitution Saving Throws',
-          'Strength Saving Throws',
-          'Charisma Saving Throws',
-          'Intelligence Saving Throws'
-        ],
-        Skills: this.skills.map(({ name }) => name)
+        Armor: ['Light Armor', 'Medium Armor', 'Heavy Armor']
       }
     }
 
@@ -85,8 +77,8 @@
       return this.chosenCategory ? this.customProficiencyList[this.chosenCategory] : Object.values(this.customProficiencyList).flat()
     }
 
-    get isSkill () {
-      return this.allProficiencies.Skills.includes(this.newProficiency)
+    get isTool () {
+      return this.toolCategories.some(category => this.allProficiencies[startCase(category)].includes(this.newProficiency))
     }
 
     resetValues () {
@@ -131,6 +123,7 @@
             v-model="chosenCategory",
             :items="proficiencyCategories",
             label="Filter by Category",
+            clearable,
             @change="newProficiency=''; isExpertise = false"
           )
           v-combobox(
@@ -144,7 +137,7 @@
               v-list-item
                 v-list-item-content
                   v-list-item-title No proficiencies matching "#[strong {{ newProficiency }} ]". Press #[kbd tab] to create a custom one
-          v-checkbox(v-if="isSkill", v-model="isExpertise", color="primary", label="Expertise")
+          v-checkbox(v-if="isTool", v-model="isExpertise", color="primary", label="Expertise")
         template(#actions)
           v-btn(color="primary", :disabled="!newProficiency", @click="handleAddProficiency") Add {{ newProficiency }}
           v-spacer

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetRest.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetRest.vue
@@ -88,7 +88,13 @@
         forcePointsUsed: 0,
         superiorityDiceUsed: 0,
         hitDiceUsed,
-        featuresTimesUsed
+        featuresTimesUsed,
+        highLevelCasting: {
+          level6: false,
+          level7: false,
+          level8: false,
+          level9: false
+        }
       } })
     }
 
@@ -137,9 +143,11 @@
           div In total, you will regain {{ pluralize(totalHealing, 'hit point') }}.
         div(v-else)
           div(v-if="hitPoints.resting.techPointsUsed") You will regain {{ pluralize(hitPoints.resting.techPointsUsed, 'tech point') }}.
-          div(v-if="hitPoints.resting.forcePointsUsed") You will regain {{ pluralize(hitPoints.resting.forcePointsUsed, 'tech point') }}.
+          div(v-if="hitPoints.resting.forcePointsUsed") You will regain {{ pluralize(hitPoints.resting.forcePointsUsed, 'force point') }}.
           div(v-if="hitPoints.current < hitPoints.maximum") You will regain {{ pluralize(hitPoints.maximum - hitPoints.current, 'hit point') }}.
           div(v-if="hitPoints.temporary") You will lose your {{ pluralize(hitPoints.temporary, 'temporary hit point') }}.
+          div(v-for="(isUsed, level) in hitPoints.resting.highLevelCasting", :key="level")
+            div(v-if="isUsed") You will regain the ability to cast a level {{ level.slice(5) }} power.
           div(v-if="hitPoints.resting.longRestFeatures.length")
             div The following features will have their uses restored:
             ul

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetSection.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetSection.vue
@@ -24,7 +24,6 @@
     @Prop(Number) readonly currentTab!: number
 
     get sections () {
-      const hasPowers = !isEmpty(this.completeCharacter.techCasting) || !isEmpty(this.completeCharacter.forceCasting)
       return [
         {
           component: 'CharacterSheetAbilities',
@@ -33,11 +32,11 @@
         {
           component: 'CharacterSheetCombat',
           icon: 'fa-fist-raised'
-        }
-      ].concat(hasPowers ? [ {
-        component: 'CharacterSheetCasting',
-        icon: 'fa-bolt'
-      }] : []).concat([
+        },
+        {
+          component: 'CharacterSheetCasting',
+          icon: 'fa-bolt'
+        },
         {
           component: 'CharacterSheetEquipment',
           icon: 'fa-toolbox'
@@ -50,7 +49,7 @@
           component: 'CharacterSheetDescription',
           icon: 'fa-user'
         }
-      ])
+      ]
     }
   }
 </script>

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetTweaker.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetTweaker.vue
@@ -48,6 +48,10 @@
       }
     }
 
+    updateProficiency (newValue: string | null, path: string) {
+      vueSetPath(this.myTweaks, `${path}.proficiency`, newValue)
+    }
+
     handleSave () {
       this.$emit('replaceCharacterProperty', { path: this.rootPath, property: this.myTweaks })
       this.isOpen = false
@@ -62,41 +66,48 @@
         slot
     template(#title) Tweak {{ title }}
     template(#text)
-      v-container
-        v-row(v-for="({ name, path, type, rootPath }) in tweakPaths", :key="path").d-flex
-          v-col(cols="4").pa-0.d-flex.align-center
-            h5 {{ name }}
-          v-col(v-if="type === 'dice'", cols="8").pa-0
-            v-select(
-              :value="myGet(myTweaks, path + '.dieSize')"
+      div(v-for="({ name, path, type, rootPath }) in tweakPaths", :key="path").d-flex.align-center
+        h5(:class="$style.label") {{ name }}
+        v-select(
+          v-if="type === 'dice'",
+          :value="myGet(myTweaks, path + '.dieSize')"
+          outlined,
+          :items="diceSizes",
+          hide-details,
+          clearable,
+          label="Dice Size",
+          @input="newValue => updateTweak(newValue, 'dieSize', path, rootPath)"
+        ).pa-1
+        div(v-else)
+          div.d-flex
+            v-text-field(
+              :value="myGet(myTweaks, path + '.bonus')"
               outlined,
-              :items="diceSizes",
+              type="number",
               hide-details,
               clearable,
-              label="Dice Size",
-              @input="newValue => updateTweak(newValue, 'dieSize', path, rootPath)"
+              label="Bonus",
+              @input="newValue => updateTweak(newValue, 'bonus', path)"
             ).pa-1
-          template(v-else)
-            v-col(cols="4").pa-0
-              v-text-field(
-                :value="myGet(myTweaks, path + '.bonus')"
-                outlined,
-                type="number",
-                hide-details,
-                clearable,
-                label="Bonus",
-                @input="newValue => updateTweak(newValue, 'bonus', path)"
-              ).pa-1
-            v-col(cols="4").pa-0
-              v-text-field(
-                :value="myGet(myTweaks, path + '.override')"
-                outlined,
-                type="number",
-                hide-details,
-                clearable,
-                label="Override",
-                @input="newValue => updateTweak(newValue, 'override', path)"
-              ).pa-1
+            v-text-field(
+              :value="myGet(myTweaks, path + '.override')"
+              outlined,
+              type="number",
+              hide-details,
+              clearable,
+              label="Override",
+              @input="newValue => updateTweak(newValue, 'override', path)"
+            ).pa-1
+          div(v-if="type === 'proficiency'")
+            v-select(
+              :value="myGet(myTweaks, path + '.proficiency')",
+              :items="[ 'Expertise', 'Proficient' ]",
+              outlined,
+              hide-details,
+              clearable,
+              label="Proficiency Level",
+              @input="newValue => updateProficiency(newValue, path)"
+            ).pa-1
     template(#actions)
       v-btn(color="primary", @click="handleSave") Save
       v-spacer
@@ -113,5 +124,9 @@
     &:hover {
       background-color: $lightGrey;
     }
+  }
+
+  .label {
+    min-width: 130px;
   }
 </style>

--- a/src/pages/MyContent/CharacterSheet/CharacterSheetWeapon.vue
+++ b/src/pages/MyContent/CharacterSheet/CharacterSheetWeapon.vue
@@ -32,7 +32,8 @@
     get damage () {
       const { damageNumberOfDice, damageDieType, damageBonus, damageType } = this.weapon
       const hasDice = damageNumberOfDice && damageDieType
-      const damage = hasDice ? damageNumberOfDice + 'd' + damageDieType + addPlus(damageBonus || 0) : damageBonus
+      const damageModifier = damageBonus ? addPlus(damageBonus) : ''
+      const damage = hasDice ? damageNumberOfDice + 'd' + damageDieType + damageModifier : damageBonus
       return damage + ' ' + damageType
     }
   }

--- a/src/pages/MyContent/Characters.vue
+++ b/src/pages/MyContent/Characters.vue
@@ -100,6 +100,10 @@
       return isEmpty(this.character) || isEqual(this.character, baseCharacter)
     }
 
+    get title () {
+      return (this.character.name || 'Characters') + Vue.prototype.$titleSuffix
+    }
+
     goToStep (step: number) {
       this.isEditing = true
       this.currentStep = step
@@ -121,6 +125,7 @@
 
 <template lang="pug">
   div(v-if="hasFetchedData")
+    vue-headful(:title="title")
     v-banner(
       :value="isDirty",
       sticky,

--- a/src/test/hanSolo.json
+++ b/src/test/hanSolo.json
@@ -85,7 +85,7 @@
   ],
   "currentStats": {
     "unspentLevels": 0,
-    "hitPointsLost": 9,
+    "hitPointsLost": 0,
     "temporaryHitPoints": 0,
     "hitDiceUsed": {
       "d8": 0

--- a/src/test/senya.json
+++ b/src/test/senya.json
@@ -199,7 +199,42 @@
         "skills": {
           "Persuasion": {
             "bonus": 4,
-            "override": null
+            "override": null,
+            "proficiency": "Expertise"
+          }
+        }
+      },
+      "Intelligence": {
+        "skills": {
+          "Investigation": {
+            "proficiency": "Proficient"
+          },
+          "Piloting": {
+            "proficiency": "Proficient"
+          }
+        },
+        "score": {
+          "bonus": 1,
+          "override": null
+        }
+      },
+      "Wisdom": {
+        "skills": {
+          "Medicine": {
+            "proficiency": "Proficient"
+          },
+          "Survival": {
+            "proficiency": "Proficient"
+          },
+          "Animal Handling": {
+            "proficiency": "Proficient"
+          }
+        }
+      },
+      "Strength": {
+        "skills": {
+          "Athletics": {
+            "proficiency": "Expertise"
           }
         }
       }
@@ -219,40 +254,12 @@
       "proficiencyLevel": "proficient"
     },
     {
-      "name": "Investigation",
-      "proficiencyLevel": "proficient"
-    },
-    {
-      "name": "Medicine",
-      "proficiencyLevel": "proficient"
-    },
-    {
-      "name": "Survival",
-      "proficiencyLevel": "proficient"
-    },
-    {
-      "name": "Animal Handling",
-      "proficiencyLevel": "proficient"
-    },
-    {
       "name": "Heavy Armor",
-      "proficiencyLevel": "proficient"
-    },
-    {
-      "name": "Piloting",
       "proficiencyLevel": "proficient"
     },
     {
       "name": "Carpenter's Kit",
       "proficiencyLevel": "proficient"
-    },
-    {
-      "name": "Persuasion",
-      "proficiencyLevel": "expertise"
-    },
-    {
-      "name": "Athletics",
-      "proficiencyLevel": "expertise"
     }
   ],
   "customLanguages": [
@@ -322,6 +329,7 @@
       "content": "You are skilled at using your shield to defend your allies as well as yourself. While you are wielding a medium or heavy shield with which you are proficient, you gain the following benefits:\r\n- When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll.\r\n- If you are wielding a heavy shield, you are no longer required to wield a weapon with the *light* property in the other hand."
     }
   ],
+  "customFeats": [],
   "settings": {
     "isFixedHitPoints": true,
     "abilityScoreMethod": "Point Buy"

--- a/src/test/senya.json
+++ b/src/test/senya.json
@@ -330,6 +330,8 @@
     }
   ],
   "customFeats": [],
+  "customTechPowers": [],
+  "customForcePowers": [ "Battle Precognition"],
   "settings": {
     "isFixedHitPoints": true,
     "abilityScoreMethod": "Point Buy"

--- a/src/types/completeCharacterTypes.ts
+++ b/src/types/completeCharacterTypes.ts
@@ -57,12 +57,12 @@ export interface TechCastingType extends CastingType {
 }
 
 export interface ForceCastingType extends CastingType {
-  lightAttackModifier: number | false,
-  lightSaveDC: number | false,
-  darkAttackModifier: number | false,
-  darkSaveDC: number | false,
-  universalAttackModifier: number | false,
-  universalSaveDC: number | false
+  lightAttackModifier: number,
+  lightSaveDC: number,
+  darkAttackModifier: number,
+  darkSaveDC: number,
+  universalAttackModifier: number,
+  universalSaveDC: number
 }
 
 export interface CharacteristicsType {

--- a/src/types/completeCharacterTypes.ts
+++ b/src/types/completeCharacterTypes.ts
@@ -1,6 +1,6 @@
 import { PowerType } from '@/types/characterTypes'
 import { EquipmentType } from '@/types/lootTypes'
-import { TweaksType, CustomProficiencyType } from './rawCharacterTypes'
+import { TweaksType, CustomProficiencyType, HighLevelCastingType } from './rawCharacterTypes'
 import { ConditionType } from './lookupTypes'
 
 export interface AbilityScoreType {
@@ -39,6 +39,7 @@ export interface HitPointsType {
     }[],
     shortRestFeatures: string[],
     longRestFeatures: string[],
+    highLevelCasting: HighLevelCastingType,
     techPointsUsed: number,
     forcePointsUsed: number
   }
@@ -159,6 +160,7 @@ export interface CompleteCharacterType {
   },
   superiority: false | SuperiorityType,
   techCasting: false | TechCastingType,
+  highLevelCasting: HighLevelCastingType,
   forceCasting: false | ForceCastingType,
   combatFeatures: CompletedFeatureType[],
   nonCombatFeatures: CompletedFeatureType[],

--- a/src/types/completeCharacterTypes.ts
+++ b/src/types/completeCharacterTypes.ts
@@ -57,12 +57,12 @@ export interface TechCastingType extends CastingType {
 }
 
 export interface ForceCastingType extends CastingType {
-  lightAttackModifier: number,
-  lightSaveDC: number,
-  darkAttackModifier: number,
-  darkSaveDC: number,
-  universalAttackModifier: number,
-  universalSaveDC: number
+  lightAttackModifier: number | false,
+  lightSaveDC: number | false,
+  darkAttackModifier: number | false,
+  darkSaveDC: number | false,
+  universalAttackModifier: number | false,
+  universalSaveDC: number | false
 }
 
 export interface CharacteristicsType {

--- a/src/types/completeCharacterTypes.ts
+++ b/src/types/completeCharacterTypes.ts
@@ -169,5 +169,7 @@ export interface CompleteCharacterType {
     name: string,
     content: string
   }[],
+  customTechPowers: string[],
+  customForcePowers: string[],
   numCustomFeats: number
 }

--- a/src/types/rawCharacterTypes.ts
+++ b/src/types/rawCharacterTypes.ts
@@ -165,6 +165,13 @@ export interface CustomProficiencyType {
 
 export type AbilityScoreMethodType = 'Standard Array' | 'Point Buy' | 'Manual'
 
+export interface HighLevelCastingType {
+  level6: boolean,
+  level7: boolean,
+  level8: boolean,
+  level9: boolean
+}
+
 export interface RawCharacterType {
   name: string,
   image: string,
@@ -199,7 +206,8 @@ export interface RawCharacterType {
       [feature: string]: number
     },
     conditions: string[],
-    exhaustion: number
+    exhaustion: number,
+    highLevelCasting: HighLevelCastingType
   },
   tweaks: TweaksType,
   customLanguages: string[],

--- a/src/types/rawCharacterTypes.ts
+++ b/src/types/rawCharacterTypes.ts
@@ -209,6 +209,8 @@ export interface RawCharacterType {
     name: string,
     content: string
   }[],
+  customTechPowers: string[],
+  customForcePowers: string[],
   settings: {
     isFixedHitPoints: boolean,
     abilityScoreMethod: AbilityScoreMethodType | string // Added | string to avoid error when importing JSON

--- a/src/types/rawCharacterTypes.ts
+++ b/src/types/rawCharacterTypes.ts
@@ -20,10 +20,6 @@ export interface RawFeatType {
 
 export interface RawArchetypeType {
   name: string,
-  silverTongue?: {
-    language: string,
-    intSkillBonus: string
-  },
   forcePowers?: string[],
   techPowers?: string[],
   maneuvers?: string[]
@@ -90,7 +86,7 @@ export interface EquipmentTweakType {
 export interface TweakPathType {
   name: string,
   path: string,
-  type?: 'dice'
+  type?: 'dice' | 'proficiency'
 }
 
 export interface RawEquipmentType {
@@ -104,7 +100,7 @@ export interface TweakType {
   override?: number,
   bonus?: number,
   dieSize?: number,
-  proficiency?: 'proficient' | 'expertise'
+  proficiency?: 'Proficient' | 'Expertise' | null
 }
 
 export interface TweaksType {


### PR DESCRIPTION
- Make class and archetype detail popups in character builder wider.
-  Add a button to view background details in character builder.
-  Select skill and save proficiency level in the tweak popup, rather than the proficiencies page
-  Allow Tool Expertise
-  Allow manually adding powers, outside powers gained from class
-  Add Cast Power Button next to power levels that automatically subtracts the appropriate number of tech/force points.
-  Changed design of force attack modifiers and save DCs based on what alignments of powers you have.
-  Use class tables to determine superiority max dice and dice size rather than formulas (Fixes bug with level 1/2 scholar having d4 superiority dice).
-  Fix issues with calculating superiority dice when multiclassing
-  Don't allow casting level 6 and higher powers more than once per long rest.
-  Add an alignment filter to force power selectors
-  Put selected powers at the top of the list in the selection popups
-  Show character name in tab title