### PR TITLE
Use DraggableList for Character Builder equipment

### DIFF
--- a/src/pages/Tools/MyCharacters/CharacterSheet/CharacterSheetEquipment.vue
+++ b/src/pages/Tools/MyCharacters/CharacterSheet/CharacterSheetEquipment.vue
@@ -1,6 +1,7 @@
 
 <script lang="ts">
   import { Component, Prop, Vue } from 'vue-property-decorator'
+  import DraggableList from '@/components/DraggableList.vue'
   import { EquipmentType } from '@/types/lootTypes'
   import { CustomEquipmentType } from '@/types/rawCharacterTypes'
   import CharacterSheetEquipmentPanel from './CharacterSheetEquipmentPanel.vue'
@@ -14,6 +15,7 @@
       CharacterSheetEquipmentPanel,
       CharacterSheetEquipmentAdder,
       CharacterSheetEquipmentCustomAdder,
+      DraggableList,
       ValueEditor
     }
   })
@@ -52,13 +54,14 @@
           @updateCharacter="newCharacter => $emit('updateCharacter', newCharacter)"
         )
     v-expansion-panels(accordion, multiple)
-      CharacterSheetEquipmentPanel(
-        v-for="(item, index) in equipment",
-        :key="index",
-        v-bind="{ item, index, attunement }",
-        @updateCharacter="newCharacter => $emit('updateCharacter', newCharacter)",
-        @deleteCharacterProperty="payload => $emit('deleteCharacterProperty', payload)"
-      )
+      DraggableList(:items="equipment", @update="equipment => $emit('updateCharacter', { equipment })")
+        CharacterSheetEquipmentPanel(
+          v-for="(item, index) in equipment",
+          :key="index",
+          v-bind="{ item, index, attunement }",
+          @updateCharacter="newCharacter => $emit('updateCharacter', newCharacter)",
+          @deleteCharacterProperty="payload => $emit('deleteCharacterProperty', payload)"
+        )
     h3.mt-3.text-left.d-flex.justify-space-between.align-end Custom Items
       CharacterSheetEquipmentCustomAdder(
         :position="customEquipment.length",


### PR DESCRIPTION
Taken from the list of feature requests (https://github.com/sangheili868/StarWars5e.Site/issues/26):  Allow reordering equipment

Utilizes the DraggableList component (currently only used for Custom Features) to allow reorganization of a character's equipment on their character sheet.