### PR TITLE
Add weight to equipment and update speed based on encumbrance

### DIFF
--- a/src/modules/CharacterEngine/generateEquipmentWeight.ts
+++ b/src/modules/CharacterEngine/generateEquipmentWeight.ts
@@ -1,0 +1,15 @@
+import { EquipmentType } from '@/types/lootTypes'
+import { CustomEquipmentType } from '@/types/rawCharacterTypes'
+
+export default function generateEquipmentWeight (
+  equipment: EquipmentType[],
+  customEquipment: CustomEquipmentType[]
+) {
+  return [...equipment, ...customEquipment]
+    .reduce((sum, item) => {
+      let weight = item.weight
+      if (typeof weight === 'string') weight = parseInt(weight)
+      if (weight) return sum + weight
+      return sum
+    }, 0)
+}

--- a/src/pages/Tools/MyCharacters/CharacterSheet/CharacterSheetCombat.vue
+++ b/src/pages/Tools/MyCharacters/CharacterSheet/CharacterSheetCombat.vue
@@ -2,7 +2,7 @@
   import { Component, Prop, Vue } from 'vue-property-decorator'
   import addPlus from '@/utilities/addPlus'
   import { EquipmentType } from '@/types/lootTypes'
-  import { SuperiorityType, CompletedFeatureType, CharacterLootType, CustomWeaponType, CharacterWeaponType } from '@/types/completeCharacterTypes'
+  import { AbilityScoresType, SuperiorityType, CompletedFeatureType, CustomWeaponType, CharacterWeaponType } from '@/types/completeCharacterTypes'
   import CharacterSheetModifier from './CharacterSheetModifier.vue'
   import CharacterSheetTweaker from './CharacterSheetTweaker.vue'
   import CharacterSheetWeapon from './CharacterSheetWeapon.vue'
@@ -11,6 +11,8 @@
   import CharacterSheetCustomFeatures from './CharacterSheetCustomFeatures.vue'
   import CharacterSheetCustomFeats from './CharacterSheetCustomFeats.vue'
   import { CustomEquipmentType, TweaksType } from '@/types/rawCharacterTypes'
+  import generateCarryingCapacity from '@/modules/CharacterEngine/generateCarryingCapacity'
+  import generateEquipmentWeight from '@/modules/CharacterEngine/generateEquipmentWeight'
 
   @Component({
     components: {
@@ -29,7 +31,7 @@
     @Prop(Number) readonly armorClass!: number
     @Prop(Array) readonly armorList!: string[]
     @Prop(Object) readonly speed!: { base: string }
-    @Prop(Array) readonly equipment!: CharacterLootType[]
+    @Prop(Array) readonly equipment!: EquipmentType[]
     @Prop(Array) readonly customEquipment!: CustomEquipmentType[]
     @Prop(Array) readonly weapons!: (CharacterWeaponType | CustomWeaponType)[]
     @Prop(Number) readonly passivePerception!: number
@@ -38,11 +40,42 @@
     @Prop(Array) readonly customFeatures!: { name: string, content: string }[]
     @Prop(Number) readonly numCustomFeats!: number
     @Prop(Object) readonly tweaks!: TweaksType
+    @Prop(Object) readonly abilityScores!: AbilityScoresType
 
     weaponTweakPaths = [
       { name: 'To Hit', path: 'weapon.toHit' },
       { name: 'Damage Bonus', path: 'weapon.damage' }
     ]
+
+    get equipmentWeight (): number {
+      return generateEquipmentWeight(this.equipment, this.customEquipment)
+    }
+
+    get carryingCapacity () {
+      return generateCarryingCapacity(this.abilityScores)
+    }
+
+    get characterSpeed (): number {
+      let speed = parseInt(this.speed.base)
+      if (!speed) { return 0 }
+      if (this.equipmentWeight > this.carryingCapacity.encumbered) {
+        speed -= 10
+      }
+      if (this.equipmentWeight > this.carryingCapacity.heavilyEncumbered) {
+        speed -= 10
+      }
+      return Math.max(speed, 0)
+    }
+
+    get speedLabel (): string {
+      if (this.equipmentWeight > this.carryingCapacity.heavilyEncumbered) {
+        return 'Speed (Heavily Encumbered)'
+      }
+      if (this.equipmentWeight > this.carryingCapacity.encumbered) {
+        return 'Speed (Encumbered)'
+      }
+      return 'Speed'
+    }
   }
 </script>
 
@@ -73,8 +106,8 @@
     )
       div.text-caption {{ armorList.join(', ') }}
     CharacterSheetModifier(
-      :value="parseInt(speed.base)"
-      label="Speed",
+      :value="characterSpeed"
+      :label="speedLabel",
       v-bind="{ tweaks }",
       tweakPath="speed.base",
       @replaceCharacterProperty="payload => $emit('replaceCharacterProperty', payload)"

--- a/src/pages/Tools/MyCharacters/CharacterSheet/CharacterSheetEquipment.vue
+++ b/src/pages/Tools/MyCharacters/CharacterSheet/CharacterSheetEquipment.vue
@@ -6,14 +6,16 @@
   import CharacterSheetEquipmentPanel from './CharacterSheetEquipmentPanel.vue'
   import CharacterSheetEquipmentAdder from './CharacterSheetEquipmentAdder.vue'
   import CharacterSheetEquipmentCustomAdder from './CharacterSheetEquipmentCustomAdder.vue'
+  import CharacterSheetEquipmentWeight from './CharacterSheetEquipmentWeight.vue'
   import ValueEditor from '@/components/ValueEditor.vue'
-  import { AttunementType } from '@/types/completeCharacterTypes'
+  import { AbilityScoresType, AttunementType } from '@/types/completeCharacterTypes'
 
   @Component({
     components: {
       CharacterSheetEquipmentPanel,
       CharacterSheetEquipmentAdder,
       CharacterSheetEquipmentCustomAdder,
+      CharacterSheetEquipmentWeight,
       ValueEditor
     }
   })
@@ -23,6 +25,7 @@
     @Prop(Object) readonly attunement!: AttunementType
     @Prop(Number) readonly credits!: number
     @Prop(Boolean) readonly isBuilder!: boolean
+    @Prop(Object) readonly abilityScores!: AbilityScoresType
   }
 </script>
 
@@ -73,4 +76,9 @@
         @updateCharacter="newCharacter => $emit('updateCharacter', newCharacter)",
         @deleteCharacterProperty="payload => $emit('deleteCharacterProperty', payload)"
       )
+    CharacterSheetEquipmentWeight(
+      :equipment="equipment",
+      :customEquipment="customEquipment",
+      :abilityScores="abilityScores",
+    )
 </template>

--- a/src/pages/Tools/MyCharacters/CharacterSheet/CharacterSheetEquipmentWeight.vue
+++ b/src/pages/Tools/MyCharacters/CharacterSheet/CharacterSheetEquipmentWeight.vue
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { Component, Prop, Vue } from 'vue-property-decorator'
+  import { AbilityScoresType } from '@/types/completeCharacterTypes'
+  import { EquipmentType } from '@/types/lootTypes'
+  import { CustomEquipmentType } from '@/types/rawCharacterTypes'
+  import generateCarryingCapacity from '@/modules/CharacterEngine/generateCarryingCapacity'
+  import generateEquipmentWeight from '@/modules/CharacterEngine/generateEquipmentWeight'
+  import ValueEditor from '@/components/ValueEditor.vue'
+
+  @Component({
+    components: {
+      ValueEditor
+    }
+  })
+  export default class CharacterSheetEquipmentWeight extends Vue {
+    @Prop(Array) readonly equipment!: EquipmentType[]
+    @Prop(Array) readonly customEquipment!: CustomEquipmentType[]
+    @Prop(Object) readonly abilityScores!: AbilityScoresType
+
+    get carryingCapacity () {
+      return generateCarryingCapacity(this.abilityScores)
+    }
+
+    get equipmentWeight (): number {
+      return generateEquipmentWeight(this.equipment, this.customEquipment)
+    }
+  }
+</script>
+
+<template lang="pug">
+  div
+    div.d-flex.align-center.mt-3
+      h4.mt-1.mr-2.text-center Weight
+      h5.text-center {{ equipmentWeight }} / {{ carryingCapacity.encumbered }}
+      h5(
+        v-if="equipmentWeight > carryingCapacity.encumbered && equipmentWeight <= carryingCapacity.heavilyEncumbered"
+      ).ml-2.text-center (Encumbered)
+      h5(
+        v-if="equipmentWeight > carryingCapacity.heavilyEncumbered"
+      ).ml-2.text-center (Heavily Encumbered)
+</template>
+
+<style lang="scss" module>
+  .checkbox {
+    flex: none !important;
+    margin-top: 0 !important;
+  }
+</style>


### PR DESCRIPTION
Taken from the list of feature requests (https://github.com/sangheili868/StarWars5e.Site/issues/26): Track Encumbrance

- Adds a section to the equipment tab that tracks weight and carrying capacity. (Updates when encumbered or heavily encumbered)
- Decreases character's speed 10 when encumbered (Adds `(Encumbered)` to the label)
- Decreases character's speed 20 when heavily encumbered. (Adds `(Heavily Encumbered)` to the label)